### PR TITLE
Test team features only when active (#698)

### DIFF
--- a/stubs/tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/tests/inertia/ApiTokenPermissionsTest.php
@@ -18,7 +18,11 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -17,7 +17,11 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $response = $this->post('/user/api-tokens', [
             'name' => 'Test Token',

--- a/stubs/tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/tests/inertia/DeleteApiTokenTest.php
@@ -18,7 +18,11 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/tests/livewire/ApiTokenPermissionsTest.php
@@ -20,7 +20,11 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -19,7 +19,11 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         Livewire::test(ApiTokenManager::class)
                     ->set(['createApiTokenForm' => [

--- a/stubs/tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/tests/livewire/DeleteApiTokenTest.php
@@ -20,7 +20,11 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if (Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',


### PR DESCRIPTION
* Test Team Features Only When Enabled

Added a condition to create the actingAs user with team features only when teams are enabled.

* Test Team Features Only When Enabled

Added a condition to create the actingAs user with team features only when teams are enabled, this time for Inertia.

* Fix formatting

Fixed an issue in the formatting spotted by StyleCI

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->
